### PR TITLE
🐦 Fix typo if user has only one follower

### DIFF
--- a/client/src/pages/Profile.js
+++ b/client/src/pages/Profile.js
@@ -142,7 +142,7 @@ export default function Profile() {
 						<div className={styles.headerBox}>
 							<Kicker>Profile</Kicker>
 							<Heading>{profileData.user.display_name}</Heading>
-							<Text>{profileData.followerCount/*profileData.user.followers.total*/} Followers</Text>
+							<Text>{profileData.followerCount == 1 ? profileData.followerCount + " Follower" : profileData.followerCount + " Followers"}</Text>
 							<div className={styles.followCopyButtonBox}>
 									{
 										auth


### PR DESCRIPTION
If a user has only one follower, spotify-social would display `1 Followers`. This fixes that bug, and is a pretty good first issue for me to get going.